### PR TITLE
Do not unsubscribe from topic when there are still listeners.

### DIFF
--- a/src/message-connector.js
+++ b/src/message-connector.js
@@ -43,8 +43,11 @@ util.inherits( MessageConnector, Connection );
  * @returns {void}
  */
 MessageConnector.prototype.unsubscribe = function( topic, callback ) {
-	this.client.unsubscribe( topic );
 	this._eventEmitter.removeListener( topic, callback );
+	//unsubscribe to redis subscription only if we have no more events listening to it
+	if ( !this._eventEmitter.listenerCount( topic ) ) {
+		this.client.unsubscribe( topic );
+	}
 };
 
 /**
@@ -60,8 +63,11 @@ MessageConnector.prototype.unsubscribe = function( topic, callback ) {
  * @returns {void}
  */
 MessageConnector.prototype.subscribe = function( topic, callback ) {
+	//subscribe to redis topic only if we have not yet subscribed (if we do not have any event listeners on that topic already)
+	if ( !this._eventEmitter.listenerCount( topic ) ) {
+		this.client.subscribe( topic );
+	}
 	this._eventEmitter.on( topic, callback );
-	this.client.subscribe( topic );
 };
 
 /**


### PR DESCRIPTION
…and only subscribe to topic if there is not an existing subscription. Including tests to ensure redis channels are subscribed and unsubscribed only when neccessary.

Fixes #2 
