### PR TITLE
Enhancement/clean connection closing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx"  ]]; then brew update   ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx"  ]]; then brew install redis  ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx"  ]]; then redis-server --daemonize yes ; fi
+
+
 env:
   global:
     - CXX=g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 env:
   global:
     - CXX=g++-4.8
-    - REDIS_HOST: 52.59.253.77
-    - REDIS_PORT: 6379
 
 # Do not insert any code under here without making sures it's in publishingtest first
 language: node_js
@@ -13,6 +11,9 @@ plugins:
     - ubuntu-toolchain-r-test
     packages:
     - g++-4.8
+
+services:
+  - redis-server
 
 node_js:
   - "stable"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+## [1.0.2] - 2016-09-13
+
+### Enhancements
+- When Deepstream quits, gracefully closes the connection to Redis
+
+### Miscellaneous
+- CI build no longer depends on external Redis
+
+## [1.0.1] - 2016-08-11
+
+### Enhancements
+- Updated example config
+
+## [1.0.0] - 2016-06-29

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,3 @@
-before_build:
-- nuget install redis-64 -excludeversion
-- redis-64\tools\redis-server.exe --service-install
-- redis-64\tools\redis-server.exe --service-start
-- '@ECHO Redis Started'
-
 # Do not insert any code under here without making sures it's in publishingtest first
 os:
   - Visual Studio 2015
@@ -14,6 +8,10 @@ platform:
 install:
   - ps: Install-Product node 4.4.5
   - npm install
+  - nuget install redis-64 -excludeversion
+  - redis-64\tools\redis-server.exe --service-install
+  - redis-64\tools\redis-server.exe --service-start
+  - '@ECHO Redis Started'
 
 test_script:
   - node --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
-environment:
-  REDIS_HOST: 52.59.253.77
-  REDIS_PORT: 6379
+before_build:
+- nuget install redis-64 -excludeversion
+- redis-64\tools\redis-server.exe --service-install
+- redis-64\tools\redis-server.exe --service-start
+- '@ECHO Redis Started'
 
 # Do not insert any code under here without making sures it's in publishingtest first
 os:

--- a/src/message-connector.js
+++ b/src/message-connector.js
@@ -30,6 +30,21 @@ var MessageConnector = function( options ) {
 util.inherits( MessageConnector, Connection )
 
 /**
+ * Gracefully close the connection to redis
+ *
+ * Called when deepstream.close() is invoked.
+ * Emits 'close' event to notify deepstream of clean closure.
+ *
+ * @public
+ * @returns {void}
+ */
+MessageConnector.prototype.close = function(){
+  this.client.removeAllListeners( 'end' )
+  this.client.once( 'end', this.emit.bind( this, 'close' ) )
+  this.client.quit()
+}
+
+/**
  * Removes <callback> as a listener and notifies the server
  * that the client is no longer interested in messages for <topic>
  *


### PR DESCRIPTION
Committed changes for clean redis connection closing – fixes e2e tests where deepstream connections are closed then reopened on a single redis instance
