### PR TITLE
Fixing cluster issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ plugins:
 #           port: <Number>
 #       redisOptions:
 #         password: 'fallback-password'
-#		  maxRedirections: 16
+#         maxRedirections: 16
 ```
 
 ## Usage in node

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ plugins:
 #           password: <String>
 #         - host: <String>
 #           port: <Number>
-#       maxRedirections: 16
 #       redisOptions:
 #         password: 'fallback-password'
+#		  maxRedirections: 16
 ```
 
 ## Usage in node

--- a/src/connection.js
+++ b/src/connection.js
@@ -21,18 +21,16 @@ var NUMBER = 'number'
  * To connect to a cluster you can use:
  *
  * {
- *   options: {
- *     nodes: [
- *       // Use password "password-for-30001" for 30001
- *       { port: <Number>, password: <String> },
- *       // Don't use password when accessing 30002
- *       { port: <Number>, password: null }
- *       // Other nodes will use "fallback-password"
- *     ],
- *     redisOptions: {
- *       password: 'fallback-password'
- *     }
- *   }
+ *    nodes: [
+ *      // Use password "password-for-30001" for 30001
+ *      { port: <Number>, password: <String> },
+ *      // Don't use password when accessing 30002
+ *      { port: <Number>, password: null }
+ *      // Other nodes will use "fallback-password"
+ *    ],
+ *    redisOptions: {
+ *      password: 'fallback-password'
+ *    }
  * }
  *
  * For more details and options see https://github.com/luin/ioredis
@@ -43,13 +41,12 @@ var Connection = function( options ) {
 
   this._validateOptions( options )
   //See https://github.com/luin/ioredis/wiki/Improve-Performance
-  options.dropBufferSupport = true
-
   if( options.nodes instanceof Array ) {
-    var nodes = options.nodes
-    delete options.nodes
-    this.client = new Redis.Cluster( nodes, options )
+	options.redisOptions.dropBufferSupport = true
+	var nodes = options.nodes
+	this.client = new Redis.Cluster( nodes, options )
   } else {
+  	options.dropBufferSupport = true
     this.client = new Redis( options )
   }
 

--- a/src/connection.js
+++ b/src/connection.js
@@ -42,11 +42,11 @@ var Connection = function( options ) {
   this._validateOptions( options )
   //See https://github.com/luin/ioredis/wiki/Improve-Performance
   if( options.nodes instanceof Array ) {
-	options.redisOptions.dropBufferSupport = true
-	var nodes = options.nodes
-	this.client = new Redis.Cluster( nodes, options )
+    options.redisOptions.dropBufferSupport = true
+    var nodes = options.nodes
+    this.client = new Redis.Cluster( nodes, options )
   } else {
-  	options.dropBufferSupport = true
+    options.dropBufferSupport = true
     this.client = new Redis( options )
   }
 


### PR DESCRIPTION
Fixes  [#465](https://github.com/deepstreamIO/deepstream.io/issues/465)

We don't need to `delete options.nodes` as it is used in the `_publishConnection`.

Also maxRedirections (and other such options) should belong in the redisOptions config object